### PR TITLE
Entries with article tags don't display correctly

### DIFF
--- a/defaults/data/feedview.css
+++ b/defaults/data/feedview.css
@@ -98,6 +98,10 @@ article {
     color: #79b0d8;
 }
 
+.content > article{
+	display:block;
+}
+
 img {
     margin: 0.75em;
 }


### PR DESCRIPTION
The entries in the [What if?](http://what-if.xkcd.com/) feed contain article tags. Because brief has `display: flex` set for those tags the entries get displayed very weird. This addition should fix that problem.