### PR TITLE
Fix Brief not reusing about:newtab at opening

### DIFF
--- a/chrome/content/brief-overlay.js
+++ b/chrome/content/brief-overlay.js
@@ -58,7 +58,7 @@ const Brief = {
 
     open: function Brief_open(aInCurrentTab) {
         let loading = gBrowser.webProgress.isLoadingDocument;
-        let blank = (gBrowser.currentURI.spec == 'about:blank');
+        let blank = isBlankPageURL(gBrowser.currentURI.spec);
         let briefTab = this.getBriefTab();
 
         if (briefTab)


### PR DESCRIPTION
[isBlankPageURL()] (http://hg.mozilla.org/mozilla-central/file/18c0f7152372/browser/base/content/utilityOverlay.js#l43) includes the handling of the **browser.newtab.url** preference, and considers the case of about:privatebrowsing.