### PR TITLE
Remove the hidechrome preference

### DIFF
--- a/chrome/content/brief-overlay.js
+++ b/chrome/content/brief-overlay.js
@@ -144,9 +144,6 @@ const Brief = {
         if (this.toolbarbutton)
             this.initUnreadCounter();
 
-        if (this.prefs.getBoolPref('hideChrome'))
-            XULBrowserWindow.inContentWhitelist.push(this.BRIEF_URL);
-
         gBrowser.addEventListener('pageshow', this.onTabLoad, false);
 
         CustomizableUI.addListener({

--- a/defaults/preferences/brief.js
+++ b/defaults/preferences/brief.js
@@ -5,7 +5,6 @@ pref("extensions.brief.lastVersion", "0");
 pref("extensions.brief@mozdev.org.description", "chrome://brief/locale/brief.properties");
 pref("extensions.brief.assumeStandardKeys", true);
 pref("extensions.brief.showFavicons", true);
-pref("extensions.brief.hideChrome", false);
 
 pref("extensions.brief.feedview.mode", 0);
 pref("extensions.brief.feedview.filterUnread", false);


### PR DESCRIPTION
I noticed it while checking the other pull request.

`XULBrowserWindow.inContentWhitelist` still exists (because add-on compat), but it is ignored:
https://bugzilla.mozilla.org/show_bug.cgi?id=752434
