### PR TITLE
Fix bugs #69 and #147

### DIFF
--- a/defaults/data/feedview.css
+++ b/defaults/data/feedview.css
@@ -20,7 +20,7 @@ body {
     padding: 0 10px 10px;
 }
 
-article {
+#feed-content > article {
     display: flex;
     align-self: stretch;
     flex-direction: row;


### PR DESCRIPTION
It's legal for an RSS entry to contain an `article` element. Ensure that we don't apply our own styling to these elements.

Fixes http://what-if.xkcd.com/feed.atom being unreadable in Brief.