### PR TITLE
Fix initialization of the unread counter if the brief button is inside the menu popup.

### DIFF
--- a/chrome/content/brief-overlay-button.jsm
+++ b/chrome/content/brief-overlay-button.jsm
@@ -1,0 +1,59 @@
+'use strict';
+
+const EXPORTED_SYMBOLS = ['briefButton'];
+
+Components.utils.import("resource://gre/modules/Console.jsm");
+Components.utils.import("resource:///modules/CustomizableUI.jsm");
+
+const BRIEF_BUTTON_ID = "brief-button";
+
+function BriefButton() {
+    this.created = false;
+}
+
+BriefButton.prototype = {
+    create: function BriefButton_create(updateStatusCb) {
+        if (this.created) {
+            return;
+        }
+
+        // only register once
+        let briefButton = CustomizableUI.createWidget({
+            id: BRIEF_BUTTON_ID,
+            type: "button",
+            label: "Brief",
+            tooltiptext: "",
+            onCreated: (node) => {
+                // mark as badged button
+                node.setAttribute('class', "toolbarbutton-1 chromeclass-toolbar-additional badged-button");
+                // set our tooltip and contextmenu
+                node.removeAttribute("tooltiptext");
+                node.setAttribute('tooltip', "brief-tooltip");
+                node.setAttribute('context', "brief-status-context");
+                // update badge
+                updateStatusCb(node);
+            },
+            onClick: (event) => {
+                if (event.button == 0 || event.button == 1) event.view.Brief.open();
+            },
+        });
+
+        CustomizableUI.addListener({
+            onCustomizeEnd: () => {
+                updateStatusCb();
+            }
+        });
+        this.created = true;
+    },
+
+    addToToolbar: function BriefButton_addToToolbar() {
+        CustomizableUI.addWidgetToArea(BRIEF_BUTTON_ID, CustomizableUI.AREA_NAVBAR);
+    },
+
+    forWindow: function BriefButton_forWindow(window) {
+        return window.document.getElementById(BRIEF_BUTTON_ID);
+    },
+};
+
+// singleton
+var briefButton = new BriefButton();

--- a/chrome/content/brief-overlay.js
+++ b/chrome/content/brief-overlay.js
@@ -129,12 +129,9 @@ var Brief = {
             }.bind(this))
         }
 
-        if (this.toolbarbutton)
-            this.initUnreadCounter();
-
+        this.initUnreadCounterContextMenu();
         CustomizableUI.addListener({
             onCustomizeEnd: () => {
-                this.initUnreadCounter();
                 this.updateStatus();
             }
         });
@@ -159,9 +156,7 @@ var Brief = {
 
     onPrefChanged: function Brief_onPrefChanged(aSubject, aTopic, aData) {
         if (aData == 'showUnreadCounter') {
-            if (Brief.toolbarbutton)
-                Brief.initUnreadCounter();
-
+            Brief.initUnreadCounterContextMenu();
             Brief.storage.ready.then(Brief.updateStatus);
         }
     },
@@ -175,9 +170,8 @@ var Brief = {
 
     onEntriesDeleted: function(aEntryList, aState) { return this.refreshUI() },
 
-    initUnreadCounter: function() {
+    initUnreadCounterContextMenu: function() {
         let showCounter = this.prefs.getBoolPref('showUnreadCounter');
-
         let menuitem = document.getElementById('brief-show-unread-counter');
         menuitem.setAttribute('checked', showCounter);
     },

--- a/chrome/content/brief-overlay.xul
+++ b/chrome/content/brief-overlay.xul
@@ -162,7 +162,8 @@
                        label="Brief"
                        tooltip="brief-tooltip"
                        context="brief-status-context"
-                       onclick="if (event.button == 0 || event.button == 1) Brief.open()" />
+                       onclick="if (event.button == 0 || event.button == 1) Brief.open()"
+                       onload="Brief.updateStatus()" />
     </toolbarpalette>
 
 </overlay>

--- a/chrome/content/brief-overlay.xul
+++ b/chrome/content/brief-overlay.xul
@@ -156,14 +156,4 @@
         </tooltip>
     </popupset>
 
-    <toolbarpalette id="BrowserToolbarPalette">
-        <toolbarbutton id="brief-button"
-                       class="toolbarbutton-1 chromeclass-toolbar-additional badged-button"
-                       label="Brief"
-                       tooltip="brief-tooltip"
-                       context="brief-status-context"
-                       onclick="if (event.button == 0 || event.button == 1) Brief.open()"
-                       onload="Brief.updateStatus()" />
-    </toolbarpalette>
-
 </overlay>


### PR DESCRIPTION
How to reproduce:
Move the brief button into the menu. Make sure to have some unread feeds.
Restart the browser and open the menu. The unread badge is not displayed.

In addition the unread counter option in the context menu is not ticked.

The pull request fixes the mentioned bugs. I'm not really sure whether using onload on a toolbarbutton is the correct way to implement this, but I couldn't find a different solution for buttons created via XUL.
