### PR TITLE
Compatibility with firefox 48

### DIFF
--- a/chrome/content/feedview.js
+++ b/chrome/content/feedview.js
@@ -1480,7 +1480,7 @@ function showElement(aElement, aAnimate) {
 }
 
 
-__defineGetter__('Strings', () => {
+this.__defineGetter__('Strings', () => {
     let cachedStringsList = [
         'entryDate.justNow',
         'minute.pluralForms',
@@ -1505,7 +1505,7 @@ __defineGetter__('Strings', () => {
     return this.Strings = obj;
 })
 
-__defineGetter__('Finder', () => {
+this.__defineGetter__('Finder', () => {
     let finder = Cc['@mozilla.org/embedcomp/rangefind;1'].createInstance(Ci.nsIFind);
     finder.caseSensitive = false;
 

--- a/modules/FeedUpdateService.jsm
+++ b/modules/FeedUpdateService.jsm
@@ -521,7 +521,17 @@ function FaviconFetcher(aFeed) {
     let websiteURI = Services.io.newURI(aFeed.websiteURL, null, null)
     let faviconURI = Services.io.newURI(websiteURI.prePath + '/favicon.ico', null, null);
 
-    let chan = Services.io.newChannelFromURI(faviconURI);
+    let chan;
+    if (Services.vc.compare(Services.appinfo.version, 47) > 0) {
+        chan = Services.io.newChannelFromURI2(faviconURI, null,
+                Services.scriptSecurityManager.getSystemPrincipal(),
+                null,
+                Components.interfaces.nsILoadInfo.SEC_NORMAL,
+                Components.interfaces.nsIContentPolicy.TYPE_OTHER
+            );
+    } else {
+        chan = Services.io.newChannelFromURI(faviconURI);
+    }
     chan.notificationCallbacks = this;
     chan.asyncOpen(this, null);
 


### PR DESCRIPTION
This replaces the legacy syntax of __defineGetter__ and switches to Services.io.newChannelFromURI2 for Firefox >= 48. The params I've used for newChannelFromURI2 work, but should be reviewed.