### PR TITLE
Partial fix for database growth

### DIFF
--- a/modules/Storage.jsm
+++ b/modules/Storage.jsm
@@ -9,6 +9,7 @@ Components.utils.import('resource://gre/modules/Task.jsm');
 Components.utils.import('resource://gre/modules/osfile.jsm');
 Components.utils.import('resource://gre/modules/Sqlite.jsm');
 Components.utils.import('resource://gre/modules/PlacesUtils.jsm');
+Components.utils.import('resource://gre/modules/FileUtils.jsm');
 
 IMPORT_COMMON(this);
 
@@ -181,6 +182,13 @@ const Storage = Object.freeze({
      */
     init: function() {
         return StorageInternal.init();
+    },
+
+    /**
+     * Opens a raw database connection, only for use by the vacuum service
+     */
+    createRawDatabaseConnection: function() {
+        return StorageInternal.createRawDatabaseConnection();
     }
 
 })
@@ -242,6 +250,12 @@ let StorageInternal = {
             this.deferredReady.resolve();
         }
     }.task(),
+
+    createRawDatabaseConnection: function StorageInternal_createRawDBConnection() {
+        let path = OS.Path.join(OS.Constants.Path.profileDir, "brief.sqlite");
+        let databaseFile = FileUtils.File(path);
+        return Services.storage.openUnsharedDatabase(databaseFile);
+    },
 
     setupDatabase: function* Database_setupDatabase() {
         makeCol = col => col['name'] + ' ' + col['type'] +

--- a/modules/Storage.jsm
+++ b/modules/Storage.jsm
@@ -13,10 +13,11 @@ Components.utils.import('resource://gre/modules/PlacesUtils.jsm');
 IMPORT_COMMON(this);
 
 
-const PURGE_ENTRIES_INTERVAL = 3600*24; // 1 day
-const DELETED_FEEDS_RETENTION_TIME = 3600*24*7; // 1 week
+// Time in milliseconds
+const PURGE_ENTRIES_INTERVAL = 3600*24*1000; // 1 day
+const DELETED_FEEDS_RETENTION_TIME = 3600*24*7*1000; // 1 week
 const LIVEMARKS_SYNC_DELAY = 100;
-const BACKUP_FILE_EXPIRATION_AGE = 3600*24*14; // 2 weeks
+const BACKUP_FILE_EXPIRATION_AGE = 3600*24*14*1000; // 2 weeks
 const DATABASE_VERSION = 18;
 const DATABASE_CACHE_SIZE = 256; // With the default page size of 32KB, it gives us 8MB of cache memory.
 
@@ -577,7 +578,7 @@ let StorageInternal = {
                 // Integer prefs are longs while Date is a long long.
                 let now = Math.round(Date.now() / 1000);
                 let lastPurgeTime = Prefs.getIntPref('database.lastPurgeTime');
-                if (now - lastPurgeTime > PURGE_ENTRIES_INTERVAL)
+                if (now - lastPurgeTime > PURGE_ENTRIES_INTERVAL/1000)
                     this.purgeDeleted();
 
                 // Remove the backup file after certain amount of time.

--- a/modules/Storage.jsm
+++ b/modules/Storage.jsm
@@ -545,6 +545,11 @@ let StorageInternal = {
             'retentionTime': DELETED_FEEDS_RETENTION_TIME
         })
 
+        // Garbage collect the full text search index
+        Stm.entriesTextSpecialCommand.execute({
+            'specialCommand': 'merge=200,8',
+        })
+
         Stm.purgeDeletedEntries.execute({
             'deletedState': Storage.ENTRY_STATE_DELETED,
             'currentDate': Date.now(),
@@ -1983,6 +1988,12 @@ let Stm = {
         let sql = 'DELETE FROM feeds                                      '+
                   'WHERE :currentDate - feeds.hidden > :retentionTime AND '+
                   '      feeds.hidden != 0                                ';
+        return new Statement(sql);
+    },
+
+    get entriesTextSpecialCommand() {
+        let sql = 'INSERT INTO entries_text(entries_text)                 '+
+                  'VALUES (:specialCommand)                               ';
         return new Statement(sql);
     },
 

--- a/modules/Storage.jsm
+++ b/modules/Storage.jsm
@@ -21,6 +21,7 @@ const LIVEMARKS_SYNC_DELAY = 100;
 const BACKUP_FILE_EXPIRATION_AGE = 3600*24*14*1000; // 2 weeks
 const DATABASE_VERSION = 18;
 const DATABASE_CACHE_SIZE = 256; // With the default page size of 32KB, it gives us 8MB of cache memory.
+const MAX_WAL_CHECKPOINT_SIZE = 16; // Checkpoint every 512KB for the default page size
 
 
 const FEEDS_COLUMNS = FEEDS_TABLE_SCHEMA.map(col => col.name);
@@ -224,6 +225,9 @@ let StorageInternal = {
         }
 
         yield Connection.execute('PRAGMA cache_size = ' + DATABASE_CACHE_SIZE);
+        // limit the WAL size
+        yield Connection.execute('PRAGMA wal_autocheckpoint = ' + MAX_WAL_CHECKPOINT_SIZE);
+        yield Connection.execute('PRAGMA journal_size_limit = ' + (3*32768*MAX_WAL_CHECKPOINT_SIZE));
 
         // Build feed cache.
         this.feedCache = [];


### PR DESCRIPTION
This is a partial fix for #194 . The included changes ensure that the full text search index is compacted and fix the vacuum service. In addition the size of the SQLite WAL is limited. The first commit fixes the premature deletion of removed feeds.

A complete fix of #194 would require some sort of automatic trash cleanup.
