### PR TITLE
Fix website being opened inside the brief tab when clicked during removal

### DIFF
--- a/chrome/content/feedview.js
+++ b/chrome/content/feedview.js
@@ -1219,8 +1219,12 @@ EntryView.prototype = {
 
     onClick: function EntryView_onClick(aEvent) {
         // If the item is already being removed, no action should be taken
-        if(this.container.getAttribute("removing"))
+        if(this.container.getAttribute("removing")) {
+            // Prevent the default action, without this
+            // clicking on removing feeds opens them in the brief tab
+            aEvent.preventDefault();
             return;
+        }
 
         this.feedView.selectEntry(this.id);
 


### PR DESCRIPTION
In order to ensure that a feed entry that is being removed causes no action, the default must be blocked.
This could fix #196.
