### PR TITLE
OPML related cleanups

### DIFF
--- a/modules/Storage.jsm
+++ b/modules/Storage.jsm
@@ -1646,7 +1646,8 @@ let BookmarkObserver = {
             this.syncDelay.then(() => {
                 this.syncDelay = null;
                 Storage.syncWithLivemarks();
-            })
+            },
+            reason => { if (reason != 'cancelled') throw reason })
         }
     },
 


### PR DESCRIPTION
These changes ensure that if a opml file contains duplicated feeds, these are only imported once. See #193 for an example of this.
In addition there are some code cleanups.
