### PR TITLE
Crop feed name if it would overflow in headline view

### DIFF
--- a/defaults/data/headlines-view.css
+++ b/defaults/data/headlines-view.css
@@ -88,6 +88,8 @@ article.selected .headline-header {
     overflow: hidden;
     font-size: 10px;
     color: #606b78;
+    white-space: nowrap;
+    text-overflow: ellipsis;
 }
 
 body:not(.multiple-feeds) .feed-icon,


### PR DESCRIPTION
Previously the feed name in a headline would be wrapped onto the next line. That way only a small part of the feed name was displayed. This patch ensures that the overflow is replaced by an ellipsis. This fixes #195.
