### PR TITLE
Replace some uses of getTopWindow

### DIFF
--- a/chrome/content/feedlist.js
+++ b/chrome/content/feedlist.js
@@ -492,7 +492,7 @@ let FeedList = {
                 break;
 
             case 'brief:custom-style-changed':
-                getTopWindow().gBrowser.getBrowserForDocument(document).reload();
+                document.location.reload();
                 break;
         }
     },


### PR DESCRIPTION
Detect tab selection using the page visibility API https://developer.mozilla.org/en-US/docs/Web/API/Page_Visibility_API
Reloading the brief tab can also be done locally.
