### PR TITLE
Simplify german context menu translation

### DIFF
--- a/chrome/locale/de/brief.dtd
+++ b/chrome/locale/de/brief.dtd
@@ -23,14 +23,14 @@
 <!-- # Context menu -->
 <!ENTITY ctxMarkRead.label "Als gelesen markieren">
 <!ENTITY ctxMarkTagRead.label "Mit Schlagwörtern versehene Beiträge als gelesen markieren">
-<!ENTITY ctxRefreshFeed.label "RSS-Feeds aktualisieren">
-<!ENTITY ctxRefreshFolder.label "Ordner aktualisieren">
+<!ENTITY ctxRefreshFeed.label "Aktualisieren">
+<!ENTITY ctxRefreshFolder.label "Aktualisieren">
 <!ENTITY ctxOpenWebsite.label "Homepage öffnen">
-<!ENTITY ctxUnsubscribeFeed.label "RSS-Feed Abbestellen">
+<!ENTITY ctxUnsubscribeFeed.label "Abbestellen">
 <!ENTITY ctxDeleteFolder.label "Ordner löschen">
 <!ENTITY ctxDeleteTag.label "Schlagwort löschen">
-<!ENTITY ctxEmptyFeed.label "Feed-Beiträge löschen">
-<!ENTITY ctxEmptyFolder.label "Beiträge des Feed-Ordners löschen">
+<!ENTITY ctxEmptyFeed.label "Beiträge löschen">
+<!ENTITY ctxEmptyFolder.label "Beiträge löschen">
 <!ENTITY ctxRestoreTrashed.label "Beiträge aus dem Papierkorb wiederherstellen">
 <!ENTITY ctxEmptyTrash.label "Papierkorb leeren">
 <!ENTITY ctxFeedSettings.label "Eigenschaften">


### PR DESCRIPTION
Simplified some german translations of the context menu -- no need to repeat in a context menu of a feed that the entry is a feed.